### PR TITLE
Remove all EXEC_CHECK from non-public functions

### DIFF
--- a/addons/behaviour/functions/fnc_getNearDeadBodies.sqf
+++ b/addons/behaviour/functions/fnc_getNearDeadBodies.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_unit", ["_radius", -1]];
 

--- a/addons/behaviour/functions/fnc_getNearEnemies.sqf
+++ b/addons/behaviour/functions/fnc_getNearEnemies.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_unit", ["_radius", -1]];
 

--- a/addons/behaviour/functions/fnc_lineOfSight.sqf
+++ b/addons/behaviour/functions/fnc_lineOfSight.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 //#define SOL_DEBUG
 //#define DEBUG_MODE_FULL

--- a/addons/behaviour/functions/fnc_shareEnemyPositions.sqf
+++ b/addons/behaviour/functions/fnc_shareEnemyPositions.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group", ["_radius", -1]];
 

--- a/addons/building/functions/fnc_filterBuildings.sqf
+++ b/addons/building/functions/fnc_filterBuildings.sqf
@@ -16,7 +16,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_buildings", "_filter"];
 

--- a/addons/building/functions/fnc_getBuildingPos.sqf
+++ b/addons/building/functions/fnc_getBuildingPos.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params [["_building", objNull]];
 

--- a/addons/building/functions/fnc_getNearBuildings.sqf
+++ b/addons/building/functions/fnc_getNearBuildings.sqf
@@ -16,7 +16,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_pos", ["_radius", 25], ["_returnNearest", false]];
 

--- a/addons/building/functions/fnc_handleEnteredBuildings.sqf
+++ b/addons/building/functions/fnc_handleEnteredBuildings.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_newBuildings"];
 

--- a/addons/building/functions/fnc_moveInBuilding.sqf
+++ b/addons/building/functions/fnc_moveInBuilding.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/building/functions/fnc_patrolBuilding.sqf
+++ b/addons/building/functions/fnc_patrolBuilding.sqf
@@ -13,7 +13,6 @@
  * Public: Yes
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_unit", ["_deleteBuildingPos", true]];
 

--- a/addons/building/functions/fnc_wasBuildingEntered.sqf
+++ b/addons/building/functions/fnc_wasBuildingEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_building"];
 

--- a/addons/caching/functions/fnc_cacheFullGroup.sqf
+++ b/addons/caching/functions/fnc_cacheFullGroup.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_cacheGroup.sqf
+++ b/addons/caching/functions/fnc_cacheGroup.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_changeLeader.sqf
+++ b/addons/caching/functions/fnc_changeLeader.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_handleCache.sqf
+++ b/addons/caching/functions/fnc_handleCache.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_handleUncache.sqf
+++ b/addons/caching/functions/fnc_handleUncache.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_moveCachedUnits.sqf
+++ b/addons/caching/functions/fnc_moveCachedUnits.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_onCacheInit.sqf
+++ b/addons/caching/functions/fnc_onCacheInit.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_shouldCache.sqf
+++ b/addons/caching/functions/fnc_shouldCache.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_uncacheFullGroup.sqf
+++ b/addons/caching/functions/fnc_uncacheFullGroup.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/caching/functions/fnc_uncacheGroup.sqf
+++ b/addons/caching/functions/fnc_uncacheGroup.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/core/functions/fnc_ModuleExpression.sqf
+++ b/addons/core/functions/fnc_ModuleExpression.sqf
@@ -1,6 +1,23 @@
 #include "script_component.hpp"
+/*
+ * Author: PiZZADOX
+ * Stores a module expression value
+ *
+ * Arguments:
+ * 0: Unit <OBJECT> (default: objNull)
+ * 1: Property name <STRING>
+ * 2: Value <ANY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, "aishootme", 1.0] call aais_core_fnc_moduleExpression
+ *
+ * Public: No
+ */
 EXEC_CHECK;
 
-params ["_obj","_propertyName","_value"];
+params ["_obj", "_propertyName", "_value"];
 
 _obj setVariable [_propertyName, _value, true];

--- a/addons/core/functions/fnc_init.sqf
+++ b/addons/core/functions/fnc_init.sqf
@@ -17,6 +17,7 @@
  *
  * Public: Yes
  */
+EXEC_CHECK(SERVERHC);
 
 params [
     ["_unit", objNull, [objNull]],

--- a/addons/spawn/functions/fnc_helperSpawnGroup.sqf
+++ b/addons/spawn/functions/fnc_helperSpawnGroup.sqf
@@ -19,7 +19,6 @@
  * Public: Yes
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_units", "_side", "_position", "_settings"];
 

--- a/addons/spawn/functions/fnc_helperSpawnInfantry.sqf
+++ b/addons/spawn/functions/fnc_helperSpawnInfantry.sqf
@@ -19,7 +19,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_configEntry", "_settings", "_side", "_size", ["_targetPos", []]];
 

--- a/addons/spawn/functions/fnc_helperSpawnVehicle.sqf
+++ b/addons/spawn/functions/fnc_helperSpawnVehicle.sqf
@@ -19,7 +19,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_configEntry", "_settings", "_side", "_size", ["_targetPos", []]];
 

--- a/addons/spawn/functions/fnc_spawnGroupPFH.sqf
+++ b/addons/spawn/functions/fnc_spawnGroupPFH.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_param", "_handle"];
 

--- a/addons/spawn/functions/fnc_spawnUnitsGroupPFH.sqf
+++ b/addons/spawn/functions/fnc_spawnUnitsGroupPFH.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group", "_handle"];
 

--- a/addons/tasks/functions/fnc_callTransport.sqf
+++ b/addons/tasks/functions/fnc_callTransport.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group", "_type", ["_requestedType", ""]];
 

--- a/addons/tasks/functions/fnc_changeAssignedTask.sqf
+++ b/addons/tasks/functions/fnc_changeAssignedTask.sqf
@@ -16,7 +16,6 @@
  * Public: Yes
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params [
     ["_group", grpNull, [grpNull]],

--- a/addons/tasks/functions/fnc_checkDoTask.sqf
+++ b/addons/tasks/functions/fnc_checkDoTask.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_moveToLand.sqf
+++ b/addons/tasks/functions/fnc_moveToLand.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onAttack.sqf
+++ b/addons/tasks/functions/fnc_onAttack.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onAttackEntered.sqf
+++ b/addons/tasks/functions/fnc_onAttackEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onDefend.sqf
+++ b/addons/tasks/functions/fnc_onDefend.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onDefendEntered.sqf
+++ b/addons/tasks/functions/fnc_onDefendEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onDisembark.sqf
+++ b/addons/tasks/functions/fnc_onDisembark.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onDisembarkEntered.sqf
+++ b/addons/tasks/functions/fnc_onDisembarkEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_onDoTaskEntered.sqf
+++ b/addons/tasks/functions/fnc_onDoTaskEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_onEmbark.sqf
+++ b/addons/tasks/functions/fnc_onEmbark.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_onEmbarkEntered.sqf
+++ b/addons/tasks/functions/fnc_onEmbarkEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 private _unitsToEmbark = (units _group) select {vehicle _x == _x && {alive _x}};

--- a/addons/tasks/functions/fnc_onFlank.sqf
+++ b/addons/tasks/functions/fnc_onFlank.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onFlankEntered.sqf
+++ b/addons/tasks/functions/fnc_onFlankEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onGarrison.sqf
+++ b/addons/tasks/functions/fnc_onGarrison.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onGarrisonEntered.sqf
+++ b/addons/tasks/functions/fnc_onGarrisonEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onInitEntered.sqf
+++ b/addons/tasks/functions/fnc_onInitEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_onPatrolBuilding.sqf
+++ b/addons/tasks/functions/fnc_onPatrolBuilding.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/tasks/functions/fnc_onPatrolBuildingEntered.sqf
+++ b/addons/tasks/functions/fnc_onPatrolBuildingEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_onPatrolEntered.sqf
+++ b/addons/tasks/functions/fnc_onPatrolEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_onPatrolRandom.sqf
+++ b/addons/tasks/functions/fnc_onPatrolRandom.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_onPatrolRandomEntered.sqf
+++ b/addons/tasks/functions/fnc_onPatrolRandomEntered.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_state"];
 

--- a/addons/tasks/functions/fnc_onTransportEntered.sqf
+++ b/addons/tasks/functions/fnc_onTransportEntered.sqf
@@ -14,6 +14,5 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];

--- a/addons/vehicle/functions/fnc_disembark.sqf
+++ b/addons/vehicle/functions/fnc_disembark.sqf
@@ -17,7 +17,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_vehicle", ["_unassign", true], ["_doPerimeter", true], ["_forceAll", false], ["_allowWater", false], ["_allowLand", true]];
 

--- a/addons/vehicle/functions/fnc_emptyPositions.sqf
+++ b/addons/vehicle/functions/fnc_emptyPositions.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_vehicle"];
 

--- a/addons/vehicle/functions/fnc_getGroupVehicles.sqf
+++ b/addons/vehicle/functions/fnc_getGroupVehicles.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/vehicle/functions/fnc_getInVehicle.sqf
+++ b/addons/vehicle/functions/fnc_getInVehicle.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_vehicle", "_units"];
 

--- a/addons/vehicle/functions/fnc_getNearVehicles.sqf
+++ b/addons/vehicle/functions/fnc_getNearVehicles.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_unit", "_distance"];
 

--- a/addons/vehicle/functions/fnc_selectUnitsDisembark.sqf
+++ b/addons/vehicle/functions/fnc_selectUnitsDisembark.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_vehicle", ["_forceAll", false]];
 

--- a/addons/waypoint/functions/fnc_addWaypoint.sqf
+++ b/addons/waypoint/functions/fnc_addWaypoint.sqf
@@ -17,7 +17,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group", "_targetPos", ["_waypointType", ""], ["_execStatements", ""], ["_condition", "true"], ["_radius", 0], ["_completionRadius", -1]];
 

--- a/addons/waypoint/functions/fnc_addWaypointMarker.sqf
+++ b/addons/waypoint/functions/fnc_addWaypointMarker.sqf
@@ -16,7 +16,6 @@
  * Public: Yes
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params [
     ["_group", grpNull, [grpNull]],

--- a/addons/waypoint/functions/fnc_checkMarkerInput.sqf
+++ b/addons/waypoint/functions/fnc_checkMarkerInput.sqf
@@ -15,7 +15,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params [
     ["_markers", "", ["", []]]

--- a/addons/waypoint/functions/fnc_clearWaypoints.sqf
+++ b/addons/waypoint/functions/fnc_clearWaypoints.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_group"];
 

--- a/addons/waypoint/functions/fnc_deleteWaypointMarker.sqf
+++ b/addons/waypoint/functions/fnc_deleteWaypointMarker.sqf
@@ -15,7 +15,6 @@
  * Public: Yes
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params [
     ["_group", grpNull, [grpNull]],

--- a/addons/waypoint/functions/fnc_elipMarkerRandomPos.sqf
+++ b/addons/waypoint/functions/fnc_elipMarkerRandomPos.sqf
@@ -18,7 +18,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_sizeX", "_sizeY", "_centerX", "_centerY", "_markerDir"];
 

--- a/addons/waypoint/functions/fnc_generatePerimeterWaypoint.sqf
+++ b/addons/waypoint/functions/fnc_generatePerimeterWaypoint.sqf
@@ -16,7 +16,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params [["_group", objNull], "_center", "_radius", ["_options", []]];
 

--- a/addons/waypoint/functions/fnc_generateWaypoint.sqf
+++ b/addons/waypoint/functions/fnc_generateWaypoint.sqf
@@ -18,7 +18,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params [["_group", objNull], "_marker", ["_options", []]];
 

--- a/addons/waypoint/functions/fnc_markerRandomBuildingPos.sqf
+++ b/addons/waypoint/functions/fnc_markerRandomBuildingPos.sqf
@@ -22,7 +22,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 // Get all buildings
 params ["_numPos", "_position", "_filter"];

--- a/addons/waypoint/functions/fnc_markerRandomPos.sqf
+++ b/addons/waypoint/functions/fnc_markerRandomPos.sqf
@@ -22,7 +22,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params [
     ["_marker", "", ["", []]],

--- a/addons/waypoint/functions/fnc_modifyWaypointMarkerWeight.sqf
+++ b/addons/waypoint/functions/fnc_modifyWaypointMarkerWeight.sqf
@@ -16,7 +16,6 @@
  * Public: Yes
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params [
     ["_group", grpNull, [grpNull]],

--- a/addons/waypoint/functions/fnc_organizeMarkers.sqf
+++ b/addons/waypoint/functions/fnc_organizeMarkers.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_markers"];
 

--- a/addons/waypoint/functions/fnc_recMarkerRandomPos.sqf
+++ b/addons/waypoint/functions/fnc_recMarkerRandomPos.sqf
@@ -18,7 +18,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params ["_sizeX", "_sizeY", "_centerX", "_centerY", "_markerDir"];
 

--- a/addons/waypoint/functions/fnc_selectRandomMarker.sqf
+++ b/addons/waypoint/functions/fnc_selectRandomMarker.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
  #include "script_component.hpp"
- EXEC_CHECK(SERVERHC);
 
 params [
     ["_markers", [], [[]]]


### PR DESCRIPTION
- Removes EXEC_CHECK from non public functions or functions called directly by the state-machine
- Add EXEC_CHECK to sys_core_fnc_init.