### PR TITLE
Do not check execution in some functions using EXEC_CHECK

### DIFF
--- a/addons/core/CfgEventHandlers.hpp
+++ b/addons/core/CfgEventHandlers.hpp
@@ -1,4 +1,3 @@
-
 class Extended_PreStart_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preStart));
@@ -8,8 +7,8 @@ class Extended_PreStart_EventHandlers {
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
-        clientinit = QUOTE(call COMPILE_FILE(XEH_preClientInit));
-        serverinit = QUOTE(call COMPILE_FILE(XEH_preServerInit));
+        clientinit = QUOTE(call COMPILE_FILE(XEH_preInitClient));
+        serverinit = QUOTE(call COMPILE_FILE(XEH_preInitServer));
     };
 };
 

--- a/addons/core/XEH_preInitClient.sqf
+++ b/addons/core/XEH_preInitClient.sqf
@@ -1,5 +1,6 @@
 #include "script_component.hpp"
-EXEC_CHECK(CLIENTHC);
+
+if (hasInterface) exitWith {}; // Do not execute this in player clients
 
 [QGVAR(settingsLoaded), {
     if (hasInterface) exitWith {};

--- a/addons/core/XEH_preInitServer.sqf
+++ b/addons/core/XEH_preInitServer.sqf
@@ -1,0 +1,4 @@
+#include "script_component.hpp"
+
+GVAR(groupRegisters) = [];
+GVAR(groupTemplates) = [] call CBA_fnc_hashCreate;

--- a/addons/core/XEH_preServerInit.sqf
+++ b/addons/core/XEH_preServerInit.sqf
@@ -1,5 +1,0 @@
-#include "script_component.hpp"
-EXEC_CHECK(SERVERHC);
-
-GVAR(groupRegisters) = [];
-GVAR(groupTemplates) = [] call CBA_fnc_hashCreate;

--- a/addons/core/functions/fnc_ModuleExpression.sqf
+++ b/addons/core/functions/fnc_ModuleExpression.sqf
@@ -16,7 +16,6 @@
  *
  * Public: No
  */
-EXEC_CHECK;
 
 params ["_obj", "_propertyName", "_value"];
 

--- a/addons/core/functions/fnc_init.sqf
+++ b/addons/core/functions/fnc_init.sqf
@@ -17,7 +17,11 @@
  *
  * Public: Yes
  */
-EXEC_CHECK(SERVERHC);
+
+// Execute only on HCs or Servers
+if (hasInterface && {!isServer}) exitWith {
+    ERROR("Init function called in a client during a multiplayer session.")
+};
 
 params [
     ["_unit", objNull, [objNull]],

--- a/addons/spawn/functions/fnc_populateMarker.sqf
+++ b/addons/spawn/functions/fnc_populateMarker.sqf
@@ -24,7 +24,10 @@
  * Public: Yes
  */
 
-EXEC_CHECK(SERVERHC); // Only execute on server or in hc
+// Execute only on HCs or Servers
+if (hasInterface && {!isServer}) exitWith {
+    ERROR("Function called in a client during a multiplayer session.")
+};
 
 params [
     ["_marker", "", ["", []]],

--- a/addons/spawn/functions/fnc_spawnGroup.sqf
+++ b/addons/spawn/functions/fnc_spawnGroup.sqf
@@ -19,7 +19,11 @@
  *
  * Public: Yes
  */
-EXEC_CHECK(SERVERHC);
+
+// Execute only on HCs or Servers
+if (hasInterface && {!isServer}) exitWith {
+    ERROR("Function called in a client during a multiplayer session.")
+};
 
 params [
     ["_units", [], [[]]],

--- a/addons/spawn/functions/fnc_spawnGroupFromTemplate.sqf
+++ b/addons/spawn/functions/fnc_spawnGroupFromTemplate.sqf
@@ -20,7 +20,10 @@
  * Public: Yes
  */
 
-EXEC_CHECK(SERVERHC);
+// Execute only on HCs or Servers
+if (hasInterface && {!isServer}) exitWith {
+    ERROR("Function called in a client during a multiplayer session.")
+};
 
 params [
     ["_templateName", "", [""]],


### PR DESCRIPTION
EXEC_CHECK also checks if AAIS is activated. When done so in Pre/Post init functions would mean that some EH will not register without a restart if AAIS is later activated. Also it makes Spawn functionality useless. AAIS should also be used to spawn units and handle control to any other AI system.

To be merged after #6