### PR TITLE
Use position error for throwGrenade

### DIFF
--- a/addons/behaviour/functions/fnc_throwGrenade.sqf
+++ b/addons/behaviour/functions/fnc_throwGrenade.sqf
@@ -24,18 +24,18 @@ private _nearestEnemy = _unit call FUNC(getNearestEnemy);
 
 if (_grenadeThrown || {isNull _nearestEnemy}) exitWith {};
 
-private _checkDistance = _unit distance _nearestEnemy; // TODO: This is not taking into account position including judgement errors and position accuracy.
-                                                       // Use targetKnowledge?
+private _targetPosition = (_unit targetKnowledge _nearestEnemy) select 6;
+private _checkDistance = _unit distance (ASLToAGL _targetPosition);
 
 if ((_checkDistance < 60) && {_checkDistance > 6}) then {
-    _unit setDir (_unit getDir _nearestEnemy);
+    _unit setDir (_unit getDir _targetPosition);
     _unit forceWeaponFire ["HandGrenadeMuzzle", "HandGrenadeMuzzle"];
     _unit forceWeaponFire ["MiniGrenadeMuzzle", "MiniGrenadeMuzzle"];
 };
 
 // TODO: Check if this can result in firing twice!
 if (GVAR(useSmoke) && {_checkDistance < 5000}) then {
-    _unit setDir (_unit getDir _nearestEnemy);
+    _unit setDir (_unit getDir _targetPosition);
     _unit forceWeaponFire ["SmokeShellMuzzle", "SmokeShellMuzzle"];
 };
 


### PR DESCRIPTION
Title. In this way, perfect location is not known to the AI, but include positioning errors.